### PR TITLE
feat: redemption rule

### DIFF
--- a/engine/src/Player.ml
+++ b/engine/src/Player.ml
@@ -48,6 +48,13 @@ module Player = struct
   let luck t = Score.luck t.items
   let total_score = score >> Score.total
 
+  let has_item token t =
+    let item = function
+      | _, 0 -> false
+      | token', _ -> token' = token
+    in
+    t.items |> List.exists item
+
   let part_sender sender_id players =
     match List.partition (id_eq sender_id) players with
     | sender :: _, recipients -> Some (sender, recipients)

--- a/engine/src/Player.ml
+++ b/engine/src/Player.ml
@@ -47,13 +47,8 @@ module Player = struct
   let cooldown token t = List.assoc_opt token t.cooldowns
   let luck t = Score.luck t.items
   let total_score = score >> Score.total
-
-  let has_item token t =
-    let item = function
-      | _, 0 -> false
-      | token', _ -> token' = token
-    in
-    t.items |> List.exists item
+  let matches_some token' (token, qty) = token' = token && qty > 0
+  let has_item token t = List.exists (matches_some token) t.items
 
   let part_sender sender_id players =
     match List.partition (id_eq sender_id) players with

--- a/engine/src/Rules.ml
+++ b/engine/src/Rules.ml
@@ -163,10 +163,12 @@ module Collection = struct
   let redemption thx deposits =
     let _sender, recipients = Thanks.parts thx in
     let tokens = Thanks.tokens thx in
-    let redeem player = Deposit.give player "💀" ~qty:(-1) ~about:"redemption" in
+    let heal player = Deposit.give player "💀" ~qty:(-1) ~about:"redemption" in
     if List.exists (( = ) "❤️") tokens then
       let redemptions =
-        recipients |> List.filter (Player.has_item "💀") |> List.map redeem
+        recipients
+        |> List.filter (Player.has_item "💀")
+        |> List.map (fun player -> heal player)
       in
       deposits @ redemptions
     else

--- a/engine/src/Rules.ml
+++ b/engine/src/Rules.ml
@@ -160,6 +160,18 @@ module Collection = struct
     else
       deposits
 
+  let redemption thx deposits =
+    let _sender, recipients = Thanks.parts thx in
+    let tokens = Thanks.tokens thx in
+    let redeem player = Deposit.give player "💀" ~qty:(-1) ~about:"redemption" in
+    if List.exists (( = ) "❤️") tokens then
+      let redemptions =
+        recipients |> List.filter (Player.has_item "💀") |> List.map redeem
+      in
+      deposits @ redemptions
+    else
+      deposits
+
   let init ~dice =
     [
       base;
@@ -171,6 +183,7 @@ module Collection = struct
       lucky ~dice;
       gift_box ~dice;
       self_penalty;
+      redemption;
     ]
 end
 

--- a/engine/test/Rules_test.ml
+++ b/engine/test/Rules_test.ml
@@ -1777,3 +1777,36 @@ module Self_penalty_test = struct
         item = ("💀", 1); about = "self-mention penalty"; cooldown = None }
       --- |}]
 end
+
+module Redemption_test = struct
+  let sender = Player.make "example_sender1"
+  let recipient1 = Player.make "example_recipient1" ~items:[ ("💀", 1) ]
+  let recipient2 = Player.make "example_recipient2"
+
+  let%expect_test "no 💀x(-1) when thanks doesn't contain ❤️" =
+    let recipients = [ recipient1; recipient2 ] in
+    let thanks = Thanks.make ~sender ~recipients "example_thanks" in
+    let received = Rules.Collection.redemption thanks [] in
+
+    List.iter print_deposit received;
+
+    [%expect {||}]
+
+  let%expect_test "💀x(-1) when recipient has 💀" =
+    let recipients = [ recipient1; recipient2; sender ] in
+    let thanks =
+      Thanks.make ~sender ~recipients ~tokens:[ "❤️" ] "example_thanks"
+    in
+    let received = Rules.Collection.redemption thanks [] in
+
+    List.iter print_deposit received;
+
+    [%expect {|
+      { player =
+        { id = "example_recipient1"; name = "player"; tz_offset = 0;
+          items = [("💀", 1)]; cooldowns = [];
+          score = { base = 0; bonus = 0; total = 0 }; highscore = 0; luck = 0;
+          is_bot = false };
+        item = ("💀", -1); about = "redemption"; cooldown = None }
+      --- |}]
+end


### PR DESCRIPTION
game engine rule that removes `💀x1` from applicable recipients when message contains `❤️`